### PR TITLE
Update depending Firebase/RemoteConfig version

### DIFF
--- a/Lobster.podspec
+++ b/Lobster.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.requires_arc     = true
   spec.static_framework = true
 
-  spec.dependency 'Firebase/RemoteConfig', '~> 6.29'
+  spec.dependency 'Firebase/RemoteConfig'
 
   spec.default_subspecs = 'Core'
 

--- a/Lobster.podspec
+++ b/Lobster.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.requires_arc     = true
   spec.static_framework = true
 
-  spec.dependency 'Firebase/RemoteConfig'
+  spec.dependency 'Firebase/RemoteConfig', '>= 7.0.0'
 
   spec.default_subspecs = 'Core'
 

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ inhibit_all_warnings!
 use_frameworks!
 
 target 'Lobster' do
-  pod 'Firebase/RemoteConfig', '~> 6.29'
+  pod 'Firebase/RemoteConfig', '~> 8.3.0'
   target 'LobsterTests' do
     inherit! :search_paths
   end

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ inhibit_all_warnings!
 use_frameworks!
 
 target 'Lobster' do
-  pod 'Firebase/RemoteConfig', '~> 8.3.0'
+  pod 'Firebase/RemoteConfig', '~> 7.0.0'
   target 'LobsterTests' do
     inherit! :search_paths
   end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,35 +1,35 @@
 PODS:
-  - Firebase/CoreOnly (8.3.0):
-    - FirebaseCore (= 8.3.0)
-  - Firebase/RemoteConfig (8.3.0):
+  - Firebase/CoreOnly (7.0.0):
+    - FirebaseCore (= 7.0.0)
+  - Firebase/RemoteConfig (7.0.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.3.0)
-  - FirebaseABTesting (8.3.0):
-    - FirebaseCore (~> 8.0)
-  - FirebaseCore (8.3.0):
-    - FirebaseCoreDiagnostics (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.3.0):
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Logger (~> 7.4)
+    - FirebaseRemoteConfig (~> 7.0.0)
+  - FirebaseABTesting (7.11.0):
+    - FirebaseCore (~> 7.0)
+  - FirebaseCore (7.0.0):
+    - FirebaseCoreDiagnostics (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Logger (~> 7.0)
+  - FirebaseCoreDiagnostics (7.11.0):
+    - GoogleDataTransport (~> 8.4)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Logger (~> 7.0)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.3.0):
-    - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/UserDefaults (~> 7.4)
+  - FirebaseInstallations (7.11.0):
+    - FirebaseCore (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseRemoteConfig (8.3.0):
-    - FirebaseABTesting (~> 8.0)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-  - GoogleDataTransport (9.1.0):
+  - FirebaseRemoteConfig (7.0.0):
+    - FirebaseABTesting (~> 7.0)
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+  - GoogleDataTransport (8.4.0):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
+    - PromisesObjC (~> 1.2)
   - GoogleUtilities/Environment (7.5.0):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.5.0):
@@ -45,7 +45,7 @@ PODS:
   - PromisesObjC (1.2.12)
 
 DEPENDENCIES:
-  - Firebase/RemoteConfig (~> 8.3.0)
+  - Firebase/RemoteConfig (~> 7.0.0)
 
 SPEC REPOS:
   trunk:
@@ -61,17 +61,17 @@ SPEC REPOS:
     - PromisesObjC
 
 SPEC CHECKSUMS:
-  Firebase: 817b9171d0d51dccc458b94a5e8edff6b1dd323d
-  FirebaseABTesting: 7fe1b1d6b2bba76d3259f5d2a2089c05faf72ff0
-  FirebaseCore: a6dba751680d7033b9d3831e1cfc95ead0605118
-  FirebaseCoreDiagnostics: 7e873baabcfaa9512f538554ae4fa0817aaafbdb
-  FirebaseInstallations: b69db7680870dbac17bba7a51fc0b5c4b365baa7
-  FirebaseRemoteConfig: 648648205dc7fd546880aeafc737bc19a2543d31
-  GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
+  Firebase: 50be68416f50eb4eb2ecb0e78acab9a051ef95df
+  FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
+  FirebaseCore: cf3122185fce1cf71cedbbc498ea84d2b3e7cb69
+  FirebaseCoreDiagnostics: 68ad972f99206cef818230f3f3179d52ccfb7f8c
+  FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
+  FirebaseRemoteConfig: ff8d3542cbd919c9d3851fd544690b8848fc0402
+  GoogleDataTransport: cd9db2180fcecd8da1b561aea31e3e56cf834aa7
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
 
-PODFILE CHECKSUM: 96a780635a7f858c98d9d3846ab268958467b2b7
+PODFILE CHECKSUM: b810c31ec6bccb2a0640a481ca7bae9dbaf16ab6
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,49 +1,51 @@
 PODS:
-  - Firebase/CoreOnly (6.29.0):
-    - FirebaseCore (= 6.9.2)
-  - Firebase/RemoteConfig (6.29.0):
+  - Firebase/CoreOnly (8.3.0):
+    - FirebaseCore (= 8.3.0)
+  - Firebase/RemoteConfig (8.3.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 4.8.0)
-  - FirebaseABTesting (4.1.0):
-    - FirebaseCore (~> 6.8)
-  - FirebaseCore (6.9.2):
-    - FirebaseCoreDiagnostics (~> 1.3)
-    - GoogleUtilities/Environment (~> 6.7)
-    - GoogleUtilities/Logger (~> 6.7)
-  - FirebaseCoreDiagnostics (1.5.0):
-    - GoogleDataTransport (~> 7.0)
-    - GoogleUtilities/Environment (~> 6.7)
-    - GoogleUtilities/Logger (~> 6.7)
-    - nanopb (~> 1.30905.0)
-  - FirebaseInstallations (1.5.0):
-    - FirebaseCore (~> 6.8)
-    - GoogleUtilities/Environment (~> 6.7)
-    - GoogleUtilities/UserDefaults (~> 6.7)
+    - FirebaseRemoteConfig (~> 8.3.0)
+  - FirebaseABTesting (8.3.0):
+    - FirebaseCore (~> 8.0)
+  - FirebaseCore (8.3.0):
+    - FirebaseCoreDiagnostics (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleUtilities/Logger (~> 7.4)
+  - FirebaseCoreDiagnostics (8.3.0):
+    - GoogleDataTransport (~> 9.0)
+    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleUtilities/Logger (~> 7.4)
+    - nanopb (~> 2.30908.0)
+  - FirebaseInstallations (8.3.0):
+    - FirebaseCore (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleUtilities/UserDefaults (~> 7.4)
     - PromisesObjC (~> 1.2)
-  - FirebaseRemoteConfig (4.8.0):
-    - FirebaseABTesting (~> 4.1)
-    - FirebaseCore (~> 6.8)
-    - FirebaseInstallations (~> 1.1)
-    - GoogleUtilities/Environment (~> 6.7)
-    - "GoogleUtilities/NSData+zlib (~> 6.7)"
-  - GoogleDataTransport (7.1.0):
-    - nanopb (~> 1.30905.0)
-  - GoogleUtilities/Environment (6.7.1):
-    - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.7.1):
+  - FirebaseRemoteConfig (8.3.0):
+    - FirebaseABTesting (~> 8.0)
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleDataTransport (9.1.0):
+    - GoogleUtilities/Environment (~> 7.2)
+    - nanopb (~> 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Environment (7.5.0):
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Logger (7.5.0):
     - GoogleUtilities/Environment
-  - "GoogleUtilities/NSData+zlib (6.7.1)"
-  - GoogleUtilities/UserDefaults (6.7.1):
+  - "GoogleUtilities/NSData+zlib (7.5.0)"
+  - GoogleUtilities/UserDefaults (7.5.0):
     - GoogleUtilities/Logger
-  - nanopb (1.30905.0):
-    - nanopb/decode (= 1.30905.0)
-    - nanopb/encode (= 1.30905.0)
-  - nanopb/decode (1.30905.0)
-  - nanopb/encode (1.30905.0)
-  - PromisesObjC (1.2.9)
+  - nanopb (2.30908.0):
+    - nanopb/decode (= 2.30908.0)
+    - nanopb/encode (= 2.30908.0)
+  - nanopb/decode (2.30908.0)
+  - nanopb/encode (2.30908.0)
+  - PromisesObjC (1.2.12)
 
 DEPENDENCIES:
-  - Firebase/RemoteConfig (~> 6.29)
+  - Firebase/RemoteConfig (~> 8.3.0)
 
 SPEC REPOS:
   trunk:
@@ -59,17 +61,17 @@ SPEC REPOS:
     - PromisesObjC
 
 SPEC CHECKSUMS:
-  Firebase: 57957c8d6eb3d8b80a560b1dc58be24724b89ff2
-  FirebaseABTesting: 9e368b88c2f1c5d7a433828d9d224779b53207b6
-  FirebaseCore: 7930a1946517d94256d857f97371ed993b55f7bd
-  FirebaseCoreDiagnostics: 7535fe695737f8c5b350584292a70b7f8ff0357b
-  FirebaseInstallations: 3c520c951305cbf9ca54eb891ff9e6d1fd384881
-  FirebaseRemoteConfig: 521ff38593bed36fcb6f466fb6fffa99a753d783
-  GoogleDataTransport: af0c79193dc59acd37630b4833d0dc6912ae6bd5
-  GoogleUtilities: e121a3867449ce16b0e35ddf1797ea7a389ffdf2
-  nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
-  PromisesObjC: b48e0338dbbac2207e611750777895f7a5811b75
+  Firebase: 817b9171d0d51dccc458b94a5e8edff6b1dd323d
+  FirebaseABTesting: 7fe1b1d6b2bba76d3259f5d2a2089c05faf72ff0
+  FirebaseCore: a6dba751680d7033b9d3831e1cfc95ead0605118
+  FirebaseCoreDiagnostics: 7e873baabcfaa9512f538554ae4fa0817aaafbdb
+  FirebaseInstallations: b69db7680870dbac17bba7a51fc0b5c4b365baa7
+  FirebaseRemoteConfig: 648648205dc7fd546880aeafc737bc19a2543d31
+  GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
+  GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
+  nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
+  PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
 
-PODFILE CHECKSUM: bdb2553bbc6762e8f0aea9c376abb9a09e9804c7
+PODFILE CHECKSUM: 96a780635a7f858c98d9d3846ab268958467b2b7
 
 COCOAPODS: 1.9.3

--- a/Sources/Core/ConfigBridge/ConfigBridge+BuiltIns.swift
+++ b/Sources/Core/ConfigBridge/ConfigBridge+BuiltIns.swift
@@ -30,7 +30,7 @@ public final class ConfigIntBridge: ConfigBridge<Int> {
     }
 
     public override func get(key: String, remoteConfig: RemoteConfig) -> T? {
-        return remoteConfig[key].numberValue?.intValue
+        return remoteConfig[key].numberValue.intValue
     }
 
     public override func get(key: String, defaultsStore: DefaultsStore) -> T? {
@@ -47,7 +47,7 @@ public final class ConfigDoubleBridge: ConfigBridge<Double> {
     }
 
     public override func get(key: String, remoteConfig: RemoteConfig) -> T? {
-        return remoteConfig[key].numberValue?.doubleValue
+        return remoteConfig[key].numberValue.doubleValue
     }
 
     public override func get(key: String, defaultsStore: DefaultsStore) -> T? {
@@ -64,7 +64,7 @@ public final class ConfigFloatBridge: ConfigBridge<Float> {
     }
 
     public override func get(key: String, remoteConfig: RemoteConfig) -> T? {
-        return remoteConfig[key].numberValue?.floatValue
+        return remoteConfig[key].numberValue.floatValue
     }
 
     public override func get(key: String, defaultsStore: DefaultsStore) -> T? {
@@ -148,7 +148,7 @@ public final class ConfigRawRepresentableBridge<T: RawRepresentable>: ConfigBrid
 
     public override func get(key: String, remoteConfig: RemoteConfig) -> T? {
         return remoteConfig[key].stringValue.flatMap(deserialize) ??
-            remoteConfig[key].numberValue.flatMap(deserialize)
+            deserialize(remoteConfig[key].numberValue)
     }
 
     public override func get(key: String, defaultsStore: DefaultsStore) -> T? {


### PR DESCRIPTION
# Purpose

We want to use Lobster with latest version Firebase SDK, but Lobster depends on v6 of it.
Then, I refined the version of Firebase SDK should be depended.
Please check this.

# What I do

- `remoteConfig[key].numberValue` becomes nonnull so that it's not needed to unwrap. (Values which is not set to RemoteConfig is decoded to 0 (0.0 for Double or Float).
  - This change has been included since v7.0.0. So I set dependency version to it.
- I checked if all tests were passed in my Firebase project setting values to RemoteConfig.